### PR TITLE
Add prebuilt msgspec wheel as a temporary measure.

### DIFF
--- a/src/models/autoBuilderWorker.js
+++ b/src/models/autoBuilderWorker.js
@@ -35,6 +35,11 @@ const setup = async () => {
   await pyodide.loadPackage('micropip');
   const micropip = pyodide.pyimport('micropip');
 
+  // After the next pyodide release, this can become micropip.install('msgspec');
+  // see https://github.com/pyodide/pyodide/issues/4264
+  console.log('Installing msgspec')
+  await micropip.install('https://cdn.jsdelivr.net/gh/mikeshardmind/wakfu-utils@d4d24e1f631b5cf99ee1d9a7ee18bb8bd954fe9c/msgspec-0.18.4-cp311-cp311-emscripten_3_1_45_wasm32.whl');
+
   // we use micropip to install the auto builder package
   console.log('Setting up the AutoBuild package loaded.');
 


### PR DESCRIPTION
adds a Prebuilt wheel for msgspec until the next pyodide release (See pyodide issue 4264)

Needed for ongoing improvements in performance
